### PR TITLE
Fix small typo in good/bad code sample.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.java
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.java
@@ -7,6 +7,6 @@ byte[] encrypted = cipher.doFinal(input.getBytes("UTF-8"));
 // ...
 
 // GOOD: AES is a strong algorithm
-Cipher des = Cipher.getInstance("AES");
+Cipher aes = Cipher.getInstance("AES");
 
 // ...


### PR DESCRIPTION
Fix a small typo in the "good/bad" Java code example associated with a CWE-327 CodeQL alert. Noticed this while discussing the alert with a developer.